### PR TITLE
修复ViewPager快速切换时，Fab可能出现状态不对的问题

### DIFF
--- a/app/src/main/java/com/xiecc/seeWeather/modules/main/ui/MainActivity.java
+++ b/app/src/main/java/com/xiecc/seeWeather/modules/main/ui/MainActivity.java
@@ -83,37 +83,31 @@ public class MainActivity extends BaseActivity implements NavigationView.OnNavig
         mAdapter.addTab(mMainFragment, "主页面");
         mAdapter.addTab(mMultiCityFragment, "多城市");
         mViewPager.setAdapter(mAdapter);
+        FabVisibilityChangedListener fabVisibilityChangedListener = new FabVisibilityChangedListener();
         mTabLayout.setupWithViewPager(mViewPager, false);
         mViewPager.addOnPageChangeListener(new ViewPager.SimpleOnPageChangeListener() {
             @Override
             public void onPageSelected(int position) {
-                mFab.post(() -> mFab.hide(new FloatingActionButton.OnVisibilityChangedListener() {
-                    @Override
-                    public void onHidden(FloatingActionButton fab) {
-                        if (position == 1) {
-                            mFab.setImageResource(R.drawable.ic_add_24dp);
-                            mFab.setBackgroundTintList(
-                                ColorStateList.valueOf(ContextCompat.getColor(MainActivity.this, R.color.colorPrimary)));
-                            mFab.setOnClickListener(v -> {
-                                Intent intent = new Intent(MainActivity.this, ChoiceCityActivity.class);
-                                intent.putExtra(C.MULTI_CHECK, true);
-                                CircularAnimUtil.startActivity(MainActivity.this, intent, mFab,
-                                    R.color.colorPrimary);
-                            });
-                        } else {
-                            mFab.setImageResource(R.drawable.ic_favorite);
-                            mFab.setBackgroundTintList(
-                                ColorStateList.valueOf(ContextCompat.getColor(MainActivity.this, R.color.colorAccent)));
-                            mFab.setOnClickListener(v -> showShareDialog());
-                        }
-                        fab.show();
-                    }
-                }));
-                if (!mFab.isShown()) {
+                if (mFab.isShown()) {
+                    fabVisibilityChangedListener.position = position;
+                    mFab.hide(fabVisibilityChangedListener);
+                } else {
+                    changeFabState(position);
                     mFab.show();
                 }
             }
         });
+    }
+
+    private class FabVisibilityChangedListener extends FloatingActionButton.OnVisibilityChangedListener {
+
+        private int position;
+
+        @Override
+        public void onHidden(FloatingActionButton fab) {
+            changeFabState(position);
+            fab.show();
+        }
     }
 
     /**
@@ -188,6 +182,22 @@ public class MainActivity extends BaseActivity implements NavigationView.OnNavig
             })
             .subscribe();
         return false;
+    }
+
+    private void changeFabState(int position) {
+        if (position == 1) {
+            mFab.setImageResource(R.drawable.ic_add_24dp);
+            mFab.setBackgroundTintList(ColorStateList.valueOf(ContextCompat.getColor(MainActivity.this, R.color.colorPrimary)));
+            mFab.setOnClickListener(v -> {
+                Intent intent = new Intent(MainActivity.this, ChoiceCityActivity.class);
+                intent.putExtra(C.MULTI_CHECK, true);
+                CircularAnimUtil.startActivity(MainActivity.this, intent, mFab, R.color.colorPrimary);
+            });
+        } else {
+            mFab.setImageResource(R.drawable.ic_favorite);
+            mFab.setBackgroundTintList(ColorStateList.valueOf(ContextCompat.getColor(MainActivity.this, R.color.colorAccent)));
+            mFab.setOnClickListener(v -> showShareDialog());
+        }
     }
 
     private void showShareDialog() {


### PR DESCRIPTION
## 问题原因
ViewPager 切换时，Fab 调用了 hide() 方法。
如果 Fab 尚未完全隐藏时，ViewPager 再次切换，则 Fab 会忽略此次 hide() 操作。（可参看 FloatingActionButtonIcs 源码中 isOrWillBeHidden() 方法和 mAnimState属性。）
而 Fab 的 onHidden() 回调中，使用的 position 被 final 修饰，导致快速切换时，回调中的 position 可能与当前不符，最终导致 ViewPager 快速切换时，Fab可能出现状态不对的问题。

## 解决方案
使用内部类替换 FloatingActionButton.OnVisibilityChangedListener 的匿名内部类，避免 position 被 final
 修饰。